### PR TITLE
feat(transformers): Add encoder, decoder, and positional layers

### DIFF
--- a/transformers/decoder.py
+++ b/transformers/decoder.py
@@ -1,0 +1,62 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+from decoder_layer import DecoderLayer
+from positional_encoding import PositionalEncoding
+
+
+class Decoder(nnx.Module):
+    def __init__(self,
+                 vocab_size,
+                 d_model,
+                 num_layers=6,
+                 num_heads=8,
+                 d_ff=2048,
+                 dropout=0.1,
+                 max_seq_length=5000, rngs: nnx.Rngs | None = None):
+
+        # Output embedding
+        self.embedding = nnx.Embed(vocab_size, d_model, rngs=rngs)
+        self.scale = jnp.sqrt(d_model)
+        # Positional encoding
+        self.pos_encoding = PositionalEncoding(d_model, max_len=max_seq_length)
+        # Decoder layers
+        self.dec_layers = [DecoderLayer(d_model, num_heads, d_ff, dropout=dropout, rngs=rngs) for _ in range(num_layers)]
+        # Dropout layer
+        self.dropout = nnx.Dropout(dropout, rngs=rngs)
+
+    def __call__(self, x, encoder_output, src_mask=None, tgt_mask=None, deterministic: bool = False):
+        seq_len = x.shape[1]
+        # Embedding and positional encoding
+        x = self.embedding(x) * self.scale
+        x = self.pos_encoding(x)
+        x = self.dropout(x, deterministic=deterministic)
+
+        # Pass through each decoder layer
+        for dec_layer in self.dec_layers:
+            x = dec_layer(x, encoder_output, src_mask, tgt_mask, deterministic=deterministic)
+
+        return x  # (batch_size, seq_len, d_model)
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    vocab_size = 1000
+    d_model = 32
+    num_layers = 2
+    num_heads = 4
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.randint(rng, (batch_size, seq_len), 0, vocab_size)
+    encoder_output = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+
+    decoder = Decoder(vocab_size=vocab_size, d_model=d_model, num_layers=num_layers,
+                      num_heads=num_heads, d_ff=d_ff, dropout=dropout_rate,
+                      max_seq_length=5000, rngs=nnx.Rngs(0))
+    out_train = decoder(x, encoder_output)  # dropout active
+    print("Train shape:", out_train.shape)
+
+    out_eval = decoder(x, encoder_output, deterministic=True)
+    print("Eval shape:", out_eval.shape)
+

--- a/transformers/decoder_layer.py
+++ b/transformers/decoder_layer.py
@@ -1,0 +1,57 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+from multi_head_attention import MultiHeadAttention
+from ffn import FeedForwardNetwork
+
+class DecoderLayer(nnx.Module):
+    def __init__(self, d_model, num_heads, d_ff, dropout=0.1, rngs: nnx.Rngs | None = None):
+        # Masked Multi-head attention
+        self.mha1 = MultiHeadAttention(d_model, num_heads, rngs=rngs)
+        # Multi-head attention over encoder output
+        self.mha2 = MultiHeadAttention(d_model, num_heads, rngs=rngs)
+        # Layer normalization
+        self.norm1 = nnx.LayerNorm(d_model, dtype=jnp.float32, rngs=rngs)
+        self.norm2 = nnx.LayerNorm(d_model, dtype=jnp.float32, rngs=rngs)
+        self.norm3 = nnx.LayerNorm(d_model, dtype=jnp.float32, rngs=rngs)
+        # Feed-forward network
+        self.ffn = FeedForwardNetwork(d_model, d_ff, dropout=dropout, rngs=rngs)
+        # Dropout layers
+        self.dropout1 = nnx.Dropout(dropout, rngs=rngs)
+        self.dropout2 = nnx.Dropout(dropout, rngs=rngs)
+        self.dropout3 = nnx.Dropout(dropout, rngs=rngs)
+    def __call__(self, x, encoder_output, src_mask=None, tgt_mask=None, deterministic: bool = False):
+        # Masked Multi-head attention
+        attn1 = self.mha1(x, x, x, mask=tgt_mask)
+        attn1 = self.dropout1(attn1, deterministic=deterministic)
+        out1 = self.norm1(x + attn1)  # Residual connection + LayerNorm
+
+        # Multi-head attention over encoder output
+        attn2 = self.mha2(out1, encoder_output, encoder_output, mask=src_mask)
+        attn2 = self.dropout2(attn2, deterministic=deterministic)
+        out2 = self.norm2(out1 + attn2)  # Residual connection + LayerNorm
+
+        # Feed-forward network
+        ffn_output = self.ffn(out2, deterministic=deterministic)
+        ffn_output = self.dropout3(ffn_output, deterministic=deterministic)
+        out3 = self.norm3(out2 + ffn_output)  # Residual connection + LayerNorm
+
+        return out3
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    d_model = 32
+    num_heads = 4
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+    encoder_output = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+
+    decoder_layer = DecoderLayer(d_model=d_model, num_heads=num_heads, d_ff=d_ff, dropout=dropout_rate, rngs=nnx.Rngs(0))
+    out_train = decoder_layer(x, encoder_output)  # dropout active
+    print("Train shape:", out_train.shape)
+
+    out_eval = decoder_layer(x, encoder_output, deterministic=True)
+    print("Eval shape:", out_eval.shape)

--- a/transformers/encoder.py
+++ b/transformers/encoder.py
@@ -1,0 +1,60 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+from encoder_layer import EncoderLayer
+from positional_encoding import PositionalEncoding
+
+class Encoder(nnx.Module):
+    def __init__(self,
+                 vocab_size,
+                 d_model,
+                 num_layers=6,
+                 num_heads=8,
+                 d_ff=2048,
+                 dropout=0.1,
+                 max_seq_length=5000, rngs: nnx.Rngs | None = None):
+
+        # Embedding layer
+        self.embedding = nnx.Embed(vocab_size, d_model, rngs=rngs)
+        self.scale = jnp.sqrt(d_model)
+        # Positional encoding
+        self.pos_encoding = PositionalEncoding(d_model, max_seq_length)
+        # Dropout layer
+        self.dropout = nnx.Dropout(dropout, rngs=rngs)
+        # Stacking multiple encoder layers
+        self.layers = [EncoderLayer(d_model, num_heads, d_ff, dropout, rngs=rngs) for _ in range(num_layers)]
+
+
+    def __call__(self, x, mask=None, deterministic: bool = False):
+        seq_len = x.shape[1]
+        # Embedding and positional encoding
+        x = self.embedding(x) * self.scale
+        x = self.pos_encoding(x)
+        x = self.dropout(x, deterministic=deterministic)
+
+        # Passing through each encoder layer
+        for layer in self.layers:
+            x = layer(x, mask=mask, deterministic=deterministic)
+
+        return x
+
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    vocab_size = 100
+    d_model = 32
+    num_layers = 2
+    num_heads = 4
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.randint(rng, (batch_size, seq_len), 0, vocab_size)
+
+    encoder = Encoder(vocab_size=vocab_size, d_model=d_model, num_layers=num_layers,
+                      num_heads=num_heads, d_ff=d_ff, dropout=dropout_rate, rngs=nnx.Rngs(0))
+    out_train = encoder(x)  # dropout active
+    print("Train shape:", out_train.shape)
+
+    out_eval = encoder(x, deterministic=True)
+    print("Eval shape:", out_eval.shape)

--- a/transformers/encoder_layer.py
+++ b/transformers/encoder_layer.py
@@ -1,0 +1,54 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+from multi_head_attention import MultiHeadAttention
+from ffn import FeedForwardNetwork
+
+
+class EncoderLayer(nnx.Module):
+    def __init__(self, d_model, num_heads, d_ff, dropout=0.1, rngs: nnx.Rngs | None = None):
+        # Multi-head self-attention
+        self.mha = MultiHeadAttention(d_model, num_heads, rngs=rngs)
+
+        # layer normalization
+        self.norm1 = nnx.LayerNorm(d_model, dtype=jnp.float32, rngs=rngs)
+        self.norm2 = nnx.LayerNorm(d_model, dtype=jnp.float32, rngs=rngs)
+
+        # Feed-forward network
+        self.ffn = FeedForwardNetwork(d_model, d_ff, dropout=dropout, rngs=rngs)
+
+        # Dropout layers
+        self.dropout1 = nnx.Dropout(dropout, rngs=rngs)
+        self.dropout2 = nnx.Dropout(dropout, rngs=rngs)
+
+    def __call__(self, x, mask=None, deterministic: bool = False):
+        # Multi-head self-attention
+        attn_output = self.mha(x, x, x, mask=mask)
+        attn_output = self.dropout1(attn_output, deterministic=deterministic)
+        out1 = self.norm1(x + attn_output)  # Residual connection + LayerNorm
+
+        # Feed-forward network
+        ffn_output = self.ffn(out1, deterministic=deterministic)
+        ffn_output = self.dropout2(ffn_output, deterministic=deterministic)
+        out2 = self.norm2(out1 + ffn_output)  # Residual connection + LayerNorm
+
+        return out2
+
+
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    d_model = 32
+    num_heads = 4
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+
+    encoder_layer = EncoderLayer(d_model=d_model, num_heads=num_heads, d_ff=d_ff, dropout=dropout_rate, rngs=nnx.Rngs(0))
+    out_train = encoder_layer(x)  # dropout active
+    print("Train shape:", out_train.shape)
+
+    out_eval = encoder_layer(x, deterministic=True)
+    print("Eval shape:", out_eval.shape)

--- a/transformers/ffn.py
+++ b/transformers/ffn.py
@@ -1,0 +1,36 @@
+import jax
+from flax import nnx
+
+
+class FeedForwardNetwork(nnx.Module):
+    def __init__(self, d_model, d_ff, dropout=0.1, rngs: nnx.Rngs | None = None):
+        self.lin1 = nnx.Linear(d_model, d_ff, rngs=rngs)
+        self.lin2 = nnx.Linear(d_ff, d_model, rngs=rngs)
+        self.dropout1 = nnx.Dropout(dropout, rngs=rngs)
+        self.dropout2 = nnx.Dropout(dropout, rngs=rngs)
+
+    def __call__(self, x, deterministic: bool = False):
+        x = self.lin1(x)
+        x = nnx.relu(x)
+        x = self.dropout1(x, deterministic=deterministic)
+        x = self.lin2(x)
+        x = self.dropout2(x, deterministic=deterministic)
+        return x
+
+
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    d_model = 32
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+
+    ffn = FeedForwardNetwork(d_model=d_model, d_ff=d_ff, dropout=dropout_rate, rngs=nnx.Rngs(0))
+    out_train = ffn(x)  # dropout active
+    print("Train shape:", out_train.shape)
+
+    out_eval = ffn(x, deterministic=True)
+    print("Eval shape:", out_eval.shape)

--- a/transformers/main.py
+++ b/transformers/main.py
@@ -1,0 +1,63 @@
+import jax
+from flax import nnx
+from encoder import Encoder
+from decoder import Decoder
+from utils import create_masks
+
+
+class Transformer(nnx.Module):
+    def __init__(self,
+                 src_vocab_size,
+                 tgt_vocab_size,
+                 d_model,
+                 num_layers=6,
+                 num_heads=8,
+                 d_ff=2048,
+                 dropout=0.1,
+                 max_seq_length=5000, rngs: nnx.Rngs | None = None):
+
+        self.encoder = Encoder(src_vocab_size, d_model, num_layers, num_heads, d_ff, dropout, max_seq_length, rngs=rngs)
+        self.decoder = Decoder(tgt_vocab_size, d_model, num_layers, num_heads, d_ff, dropout, max_seq_length, rngs=rngs)
+        # in_features should be d_model
+        self.final_layer = nnx.Linear(d_model, tgt_vocab_size, rngs=rngs)
+
+    def __call__(self, src, tgt, deterministic: bool = False):
+        src_mask, tgt_mask = create_masks(src, tgt)
+
+        enc_output = self.encoder(src, mask=src_mask, deterministic=deterministic)
+        dec_output = self.decoder(tgt, enc_output, src_mask=src_mask, tgt_mask=tgt_mask, deterministic=deterministic)
+
+        final_output = self.final_layer(dec_output)
+        return final_output
+
+
+if __name__ == "__main__":
+    batch_size = 2
+    src_seq_len = 5
+    tgt_seq_len = 6
+    src_vocab_size = 100
+    tgt_vocab_size = 100
+    d_model = 32
+    num_layers = 2
+    num_heads = 4
+    d_ff = 64
+    dropout_rate = 0.1
+
+    rng = jax.random.PRNGKey(0)
+    src = jax.random.randint(rng, (batch_size, src_seq_len), 0, src_vocab_size)
+    tgt = jax.random.randint(rng, (batch_size, tgt_seq_len), 0, tgt_vocab_size)
+
+    transformer = Transformer(src_vocab_size=src_vocab_size,
+                              tgt_vocab_size=tgt_vocab_size,
+                              d_model=d_model,
+                              num_layers=num_layers,
+                              num_heads=num_heads,
+                              d_ff=d_ff,
+                              dropout=dropout_rate,
+                              rngs=nnx.Rngs(0))
+
+    out_train = transformer(src, tgt)
+    print("Train shape:", out_train.shape)
+
+    out_eval = transformer(src, tgt, deterministic=True)
+    print("Eval shape:", out_eval.shape)

--- a/transformers/multi_head_attention.py
+++ b/transformers/multi_head_attention.py
@@ -1,0 +1,80 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+
+def scaled_dot_product_attention(query, key, value, mask=None):
+    """
+    Args:
+        query: (batch_size, num_heads, seq_len_q, d_k)
+        key: (batch_size, num_heads, seq_len_k, d_k)
+        value: (batch_size, num_heads, seq_len_v, d_v)
+        mask: boolean mask broadcastable to (batch_size, num_heads, seq_len_q, seq_len_k)
+              True = keep, False = mask out
+    """
+    d_k = query.shape[-1]
+    scores = jnp.matmul(query, jnp.swapaxes(key, -2, -1)) / jnp.sqrt(d_k)
+
+    if mask is not None:
+        # Ensure mask is bool; set masked positions to large negative
+        scores = jnp.where(mask, scores, jnp.finfo(scores.dtype).min)
+
+    attn_weights = nnx.softmax(scores, axis=-1)
+    output = jnp.matmul(attn_weights, value)
+    return output
+
+
+class MultiHeadAttention(nnx.Module):
+    def __init__(self, d_model, num_heads, rngs: nnx.Rngs):
+        self.d_model = d_model
+        self.num_heads = num_heads
+        self.d_k = d_model // num_heads  # Note: use integer division //
+
+        # Create the learnable projection matrices
+        self.W_q = nnx.Linear(d_model, d_model, rngs=rngs) #think why we are doing from d_model -> d_model
+        self.W_k = nnx.Linear(d_model, d_model, rngs=rngs)
+        self.W_v = nnx.Linear(d_model, d_model, rngs=rngs)
+        self.W_o = nnx.Linear(d_model, d_model, rngs=rngs)
+
+    def __call__(self, query, key, value, mask=None):
+        batch_size = query.shape[0]
+
+        # Linear projections
+        query = self.W_q(query)  # (batch_size, seq_len, d_model)
+        key = self.W_k(key)      # (batch_size, seq_len, d_model)
+        value = self.W_v(value)  # (batch_size, seq_len, d_model)
+
+        # Reshape and transpose for multi-head attention
+        def reshape_for_heads(x):
+            x = x.reshape(batch_size, -1, self.num_heads, self.d_k)
+            return jnp.transpose(x, (0, 2, 1, 3))  # (batch_size, num_heads, seq_len, d_k)
+
+        query = reshape_for_heads(query)
+        key = reshape_for_heads(key)
+        value = reshape_for_heads(value)
+
+        # Apply scaled dot-product attention
+        attn_output = scaled_dot_product_attention(query, key, value, mask)  # (batch_size, num_heads, seq_len, d_k)
+
+        # Concatenate heads and put through the final linear layer
+        attn_output = jnp.transpose(attn_output, (0, 2, 1, 3))  # (batch_size, seq_len, num_heads, d_k)
+        attn_output = attn_output.reshape(batch_size, -1, self.d_model)  # (batch_size, seq_len, d_model)
+
+        output = self.W_o(attn_output)  # (batch_size, seq_len, d_model)
+        return output
+
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    d_model = 32
+    num_heads = 4
+
+    rng = jax.random.PRNGKey(0)
+    rng, q_key, k_key, v_key = jax.random.split(rng, 4)
+
+    query = jax.random.uniform(q_key, (batch_size, seq_len, d_model))
+    key = jax.random.uniform(k_key, (batch_size, seq_len, d_model))
+    value = jax.random.uniform(v_key, (batch_size, seq_len, d_model))
+
+    mha = MultiHeadAttention(d_model=d_model, num_heads=num_heads, rngs=nnx.Rngs(0))
+    output = mha(query, key, value)
+    print("Output shape:", output.shape)

--- a/transformers/positional_encoding.py
+++ b/transformers/positional_encoding.py
@@ -1,0 +1,26 @@
+from jax import numpy as jnp
+import jax
+from flax import nnx
+
+class PositionalEncoding(nnx.Module):
+    def __init__(self, d_model: int, max_len: int = 5000):
+        position = jnp.arange(max_len)[:, None]
+        div_term = jnp.exp(jnp.arange(0, d_model, 2) * (-jnp.log(10000.0) / d_model))
+        pe = jnp.zeros((max_len, d_model))
+        pe = pe.at[:, 0::2].set(jnp.sin(position * div_term))
+        pe = pe.at[:, 1::2].set(jnp.cos(position * div_term))
+        self.pe = jnp.expand_dims(pe, axis=0)                         # (1, max_len, d_model)
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        seq_len = x.shape[1]
+        return x + self.pe[:, :seq_len]
+
+if __name__ == "__main__":
+    batch_size = 2
+    seq_len = 5
+    d_model = 32
+    rng = jax.random.PRNGKey(0)
+    x = jax.random.uniform(rng, (batch_size, seq_len, d_model))
+    pos_enc = PositionalEncoding(d_model=d_model, max_len=5000)
+    out = pos_enc(x)
+    print("Output shape:", out.shape)

--- a/transformers/training.py
+++ b/transformers/training.py
@@ -1,0 +1,90 @@
+import jax
+from jax import numpy as jnp
+from flax import nnx
+import optax
+from typing import Tuple
+from main import Transformer
+
+# Hyperparameters
+SRC_VOCAB = 100
+TGT_VOCAB = 100
+D_MODEL = 32
+LR = 1e-3
+LABEL_SMOOTH = 0.1
+GRAD_CLIP_NORM = 1.0
+NUM_STEPS = 10
+BATCH = 2
+SRC_LEN = 5
+TGT_LEN = 6  # includes BOS for input and shifted target
+
+# Model
+model = Transformer(
+        src_vocab_size=SRC_VOCAB,
+        tgt_vocab_size=TGT_VOCAB,
+        d_model=D_MODEL,
+        num_layers=2,
+        num_heads=4,
+        d_ff=64,
+        dropout=0.1,
+        rngs=nnx.Rngs(0),
+)
+
+# Optimizer (with optional gradient clipping)
+optimizer = nnx.Optimizer(
+        model,
+        optax.chain(
+                optax.clip_by_global_norm(GRAD_CLIP_NORM),
+                optax.adam(LR),
+        ),
+        wrt=nnx.Param,
+)
+
+def label_smoothing_loss(
+        logits: jnp.ndarray,
+        targets: jnp.ndarray,
+        epsilon: float = LABEL_SMOOTH,
+) -> jnp.ndarray:
+    """Efficient label smoothing cross entropy."""
+    log_probs = jax.nn.log_softmax(logits, axis=-1)                      # [B, T, V]
+    # Gather log p(y_true)
+    true_logp = jnp.take_along_axis(log_probs, targets[..., None], axis=-1).squeeze(-1)  # [B, T]
+    nll = -true_logp
+    # Cross entropy with uniform distribution
+    uniform_ce = -jnp.mean(log_probs, axis=-1)  # [B, T]
+    loss = (1.0 - epsilon) * nll + epsilon * uniform_ce
+    return jnp.mean(loss)
+
+@nnx.jit
+def train_step(
+        model: Transformer,
+        optimizer: nnx.Optimizer,
+        rng: jax.Array,
+        src: jnp.ndarray,
+        tgt_inp: jnp.ndarray,
+        tgt_out: jnp.ndarray,
+) -> Tuple[jnp.ndarray, jax.Array]:
+    """One training step."""
+    # Advance rngs for dropout
+    model.rngs = nnx.Rngs(rng)
+
+    def loss_fn(m: Transformer):
+        logits = m(src, tgt_inp, deterministic=False)  # [B, T, V]
+        return label_smoothing_loss(logits, tgt_out, LABEL_SMOOTH)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(model)
+    optimizer.update(model, grads)
+    return loss, jax.random.split(rng, 2)[0]
+
+# Synthetic data
+key = jax.random.PRNGKey(42)
+key_src, key_tgt, key_loop = jax.random.split(key, 3)
+X_src = jax.random.randint(key_src, (BATCH, SRC_LEN), 0, SRC_VOCAB)
+X_tgt_full = jax.random.randint(key_tgt, (BATCH, TGT_LEN), 0, TGT_VOCAB)
+
+# Training loop
+for step in range(1, NUM_STEPS + 1):
+    tgt_input = X_tgt_full[:, :-1]   # teacher forcing input
+    tgt_target = X_tgt_full[:, 1:]   # shifted targets
+    loss, key_loop = train_step(model, optimizer, key_loop, X_src, tgt_input, tgt_target)
+    if step % 1 == 0:
+        print(f"step={step} loss={float(loss):.4f}")

--- a/transformers/utils.py
+++ b/transformers/utils.py
@@ -1,0 +1,46 @@
+from jax import numpy as jnp
+
+def create_padding_mask(seq):
+    seq = jnp.array(seq)
+    # True where padding (token id 0)
+    mask = (seq == 0)
+    return mask[:, jnp.newaxis, jnp.newaxis, :]  # (batch, 1, 1, seq_len)
+
+def create_future_mask(size):
+    # True where positions should be masked (future tokens)
+    return jnp.triu(jnp.ones((1, 1, size, size), dtype=bool), k=1)
+
+def create_masks(src, tgt):
+    src = jnp.array(src)
+    tgt = jnp.array(tgt)
+
+    src_padding_mask = create_padding_mask(src)                 # (batch,1,1,src_len)
+    tgt_padding_mask = create_padding_mask(tgt)                 # (batch,1,1,tgt_len)
+
+    tgt_len = tgt.shape[1]
+    future_mask = create_future_mask(tgt_len)                   # (1,1,tgt_len,tgt_len)
+
+    # Broadcast padding mask over query length
+    tgt_padding_broadcast = jnp.broadcast_to(
+            tgt_padding_mask, (tgt.shape[0], 1, tgt_len, tgt_len)
+    )                                                           # (batch,1,tgt_len,tgt_len)
+
+    # Combined mask: True means "mask out"
+    tgt_mask = jnp.logical_or(future_mask, tgt_padding_broadcast)
+
+    return src_padding_mask, tgt_mask
+
+if __name__ == "__main__":
+    src = jnp.array([[7, 6, 0, 0, 0],
+                     [1, 2, 3, 0, 0],
+                     [4, 5, 6, 7, 8]])
+
+    tgt = jnp.array([[1, 2, 3, 0],
+                     [4, 5, 0, 0],
+                     [6, 7, 8, 9]])
+
+    src_mask, tgt_mask = create_masks(src, tgt)
+    print("Source mask shape:", src_mask.shape)
+    print("Target mask shape:", tgt_mask.shape)
+    print("Source mask:\n", src_mask.astype(int))
+    print("Target mask (1 means masked):\n", tgt_mask.astype(int))


### PR DESCRIPTION
Implement core transformer architecture components using Flax and
JAX. Add EncoderLayer, DecoderLayer, and PositionalEncoding classes
with support for multi-head attention, layer normalization, and
dropout. Includes example usage and shape validation for each
component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a full Transformer model with encoder/decoder stacks, multi-head attention, positional encoding, and feed-forward layers.
  - Adds training and evaluation modes (dropout-aware) with runnable examples.
  - Provides masking utilities for padding and future-token masking.
  - Includes label-smoothed loss, a JIT-compiled training step, and a simple training loop with optimization.
  - Exposes configurable hyperparameters (vocab sizes, model dimension, layer count, heads, dropout, sequence length).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->