### PR TITLE
feat(visualization): Add Grad-CAM visualization for CNN model

### DIFF
--- a/cnn_with_grad_cam/cnn.py
+++ b/cnn_with_grad_cam/cnn.py
@@ -1,0 +1,89 @@
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+class Net(nnx.Module):
+    def __init__(self, *, rngs: nnx.Rngs):
+        self.conv1 = nnx.Conv(3, 128, kernel_size=5, padding=2, rngs=rngs)
+        self.conv2 = nnx.Conv(128, 128, kernel_size=5, padding=2, rngs=rngs)
+        self.conv3 = nnx.Conv(128, 256, kernel_size=3, padding=1, rngs=rngs)
+        self.conv4 = nnx.Conv(256, 256, kernel_size=3, padding=1, rngs=rngs)
+
+        self.bn_conv1 = nnx.BatchNorm(128, rngs=rngs)
+        self.bn_conv2 = nnx.BatchNorm(128, rngs=rngs)
+        self.bn_conv3 = nnx.BatchNorm(256, rngs=rngs)
+        self.bn_conv4 = nnx.BatchNorm(256, rngs=rngs)
+        # Removed axis_name (was causing unbound axis error)
+        self.bn_dense1 = nnx.BatchNorm(1024, rngs=rngs)
+        self.bn_dense2 = nnx.BatchNorm(512, rngs=rngs)
+
+        self.dropout_conv = nnx.Dropout(rate=0.25, rngs=rngs)
+        self.dropout = nnx.Dropout(rate=0.5, rngs=rngs)
+
+        self.fc1 = nnx.Linear(256 * 8 * 8, 1024, rngs=rngs)
+        self.fc2 = nnx.Linear(1024, 512, rngs=rngs)
+        self.fc3 = nnx.Linear(512, 10, rngs=rngs)
+
+        self.pool = lambda x: nnx.max_pool(x, window_shape=(2, 2), strides=(2, 2))
+
+    def conv_layers(self, x, training: bool = True):
+        out = self.conv1(x)
+        out = self.bn_conv1(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn_conv2(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+
+        out = self.pool(out)
+        out = self.dropout_conv(out, deterministic=not training)
+
+        out = self.conv3(out)
+        out = self.bn_conv3(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+
+        out = self.conv4(out)
+        out = self.bn_conv4(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+        conv4_activations = out  # Save for Grad-CAM
+
+        out = self.pool(out)
+        out = self.dropout_conv(out, deterministic=not training)
+        return out, conv4_activations
+
+    def dense_layers(self, x, training: bool = True):
+        out = self.fc1(x)
+        out = self.bn_dense1(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+        out = self.dropout(out, deterministic=not training)
+
+        out = self.fc2(out)
+        out = self.bn_dense2(out, use_running_average=not training)
+        out = jax.nn.relu(out)
+        out = self.dropout(out, deterministic=not training)
+
+        out = self.fc3(out)
+        return out
+
+    def __call__(self, x, training: bool = True):
+        out, conv4_activations = self.conv_layers(x, training=training)
+        out = out.reshape(out.shape[0], -1)  # flatten
+        out = self.dense_layers(out, training=training)
+        return out, conv4_activations
+
+if __name__ == "__main__":
+    # Initialize model
+    rngs = nnx.Rngs(0)
+    model = Net(rngs=rngs)
+
+    # Dummy input
+    x = jnp.ones((4, 32, 32, 3))  # NHWC format (Flax uses channels-last)
+
+    # Forward pass (training mode)
+    logits, conv4_activations = model(x, training=True)
+
+    # Forward pass (eval mode)
+    logits_eval, _ = model(x, training=False)
+    print("Logits shape (training):", logits.shape)
+    print("Logits shape (eval):", logits_eval.shape)
+    print("Conv4 activations shape:", conv4_activations.shape)

--- a/cnn_with_grad_cam/main.py
+++ b/cnn_with_grad_cam/main.py
@@ -1,0 +1,127 @@
+import jax
+import jax.numpy as jnp
+from jax import grad
+import jax.image as jimg
+from flax import nnx
+import numpy as np
+import matplotlib.pyplot as plt
+from cnn import Net
+from training import load_cifar10, main
+
+
+def _normalize_cam(cam: jnp.ndarray) -> jnp.ndarray:
+    cam = jnp.maximum(cam, 0.0)
+    denom = jnp.max(cam)
+    cam = jnp.where(denom > 0, cam / (denom + 1e-8), cam)
+    return cam
+
+
+def grad_cam(model, x, target_class: int | None = None, training: bool = False):
+    """
+    Supports x shape (H,W,C) or (B,H,W,C).
+    Returns (cams, pred_classes):
+      cams: (B,H,W) jnp.ndarray
+      pred_classes: (B,) numpy array
+    """
+    single = False
+    if x.ndim == 3:
+        x = x[None, ...]
+        single = True
+
+    # Forward to obtain logits + saved conv activations
+    logits, conv_acts = model(x, training=training)  # conv_acts: (B,Hc,Wc,Cc)
+    pred_classes = jnp.argmax(logits, axis=-1)
+    if target_class is None:
+        target_class = pred_classes  # shape (B,)
+    else:
+        target_class = jnp.full(pred_classes.shape, target_class, dtype=jnp.int32)
+
+    def per_example(cam_feats, cls_idx):
+        # cam_feats: (Hc,Wc,Cc)
+        def get_target_logit(conv4_act):
+            pooled = model.pool(conv4_act[None, ...])         # (1,Hp,Wp,Cc)
+            flat = pooled.reshape(1, -1)
+            local_logits = model.dense_layers(flat, training=training)
+            return local_logits[0, cls_idx]
+
+        g = grad(get_target_logit)(cam_feats)
+        weights = jnp.mean(g, axis=(0, 1))                   # (Cc,)
+        cam_map = jnp.tensordot(cam_feats, weights, axes=([-1], [0]))  # (Hc,Wc)
+        return _normalize_cam(cam_map)
+
+    cams = jax.vmap(per_example)(conv_acts, target_class)
+
+    if single:
+        return np.array(cams[0]), int(pred_classes[0])
+    return np.array(cams), np.array(pred_classes)
+
+
+def _resize_cam_to_image(cam: np.ndarray, img_hw: tuple[int, int]) -> np.ndarray:
+    if cam.shape != img_hw:
+        cam_j = jnp.array(cam)[None, ..., None]
+        resized = jimg.resize(cam_j, (1, img_hw[0], img_hw[1], 1), method="bilinear")[0, ..., 0]
+        return np.array(resized)
+    return cam
+
+
+def _first_indices_per_class(labels: np.ndarray, num_classes: int) -> np.ndarray:
+    # Returns the first occurrence index for each class 0..num_classes-1
+    idxs = [int(np.where(labels == c)[0][0]) for c in range(num_classes)]
+    return np.array(idxs, dtype=np.int32)
+
+
+def _plot_gradcams(model, images, labels, out_file: str, title_prefix: str):
+    rows, cols = 2, images.shape[0]
+    plt.figure(figsize=(cols * 1.9, rows * 2.0))
+    for i in range(cols):
+        img = images[i]
+        true_label = int(labels[i])
+        cam, pred = grad_cam(model, img, training=False)
+        cam = _resize_cam_to_image(cam, img.shape[:2])
+
+        # Original
+        plt.subplot(rows, cols, i + 1)
+        plt.imshow(np.array(img))
+        plt.title(f"T:{true_label}")
+        plt.axis("off")
+
+        # Overlay
+        plt.subplot(rows, cols, cols + i + 1)
+        plt.imshow(np.array(img), alpha=0.65)
+        plt.imshow(cam, cmap="jet", alpha=0.35)
+        plt.title(f"P:{pred}")
+        plt.axis("off")
+
+    plt.tight_layout()
+    plt.savefig(out_file, dpi=160, bbox_inches="tight")
+    print(f"Saved to {out_file}")
+    plt.close()
+
+
+def main_visualization():
+    rngs = nnx.Rngs(0)
+    model = Net(rngs=rngs)
+    train_imgs, train_labels, test_imgs, test_labels = load_cifar10()
+
+    # Select one sample per class
+    test_labels_np = np.array(test_labels)
+    sel_idx = _first_indices_per_class(test_labels_np, num_classes=10)
+    sample_images = test_imgs[sel_idx]
+    sample_labels = test_labels[sel_idx]
+
+    # Before training
+    _plot_gradcams(model, sample_images, sample_labels,
+                   out_file="true_and_gradcam.png",
+                   title_prefix="Before")
+
+    # Train (assumes training.main returns (state, trained_model))
+    _, trained_model = main()
+
+    # After training
+    _plot_gradcams(trained_model, sample_images, sample_labels,
+                   out_file="true_and_gradcam_after_training.png",
+                   title_prefix="After")
+
+
+if __name__ == "__main__":
+    main_visualization()

--- a/cnn_with_grad_cam/training.py
+++ b/cnn_with_grad_cam/training.py
@@ -1,0 +1,110 @@
+import numpy as np
+from jax import numpy as jnp
+from flax import nnx
+from torchvision.datasets import CIFAR10
+import optax
+from cnn import Net
+
+# Hyperparameters
+LEARNING_RATE = 5e-3
+BATCH_SIZE = 256
+EVAL_EVERY = 1
+NUM_EPOCHS = 20
+RNG_SEED = 0
+
+def load_cifar10(root: str = "data"):
+    """Load CIFAR-10 into contiguous jnp arrays (NHWC, float32 in [0,1])."""
+    train_ds = CIFAR10(root, download=True, train=True)
+    test_ds = CIFAR10(root, download=True, train=False)
+
+    def to_array(ds):
+        imgs = np.stack([np.asarray(img, dtype=np.float32) for img, _ in ds], axis=0) / 255.0
+        labels = np.array([label for _, label in ds], dtype=np.int32)
+        return jnp.asarray(imgs), jnp.asarray(labels)
+
+    return (*to_array(train_ds), *to_array(test_ds))
+
+def batch_iterator(images, labels, batch_size: int, rng: np.random.Generator, shuffle: bool = True):
+    """Yield mini-batches as dicts with keys 'image' and 'label'."""
+    n = images.shape[0]
+    idxs = rng.permutation(n) if shuffle else np.arange(n)
+    for start in range(0, n, batch_size):
+        sl = idxs[start:start + batch_size]
+        yield {'image': images[sl], 'label': labels[sl]}
+
+def loss_fn(model: Net, batch):
+    logits, _ = model(batch['image'])
+    loss = optax.softmax_cross_entropy_with_integer_labels(
+            logits=logits, labels=batch['label']
+    ).mean()
+    return loss, logits
+
+@nnx.jit
+def train_step(model: Net, optimizer: nnx.Optimizer, metrics: nnx.MultiMetric, batch):
+    grad_fn = nnx.value_and_grad(loss_fn, has_aux=True)
+    (loss, logits), grads = grad_fn(model, batch)
+    metrics.update(loss=loss, logits=logits, labels=batch['label'])
+    optimizer.update(model, grads)
+
+@nnx.jit
+def eval_step(model: Net, metrics: nnx.MultiMetric, batch):
+    loss, logits = loss_fn(model, batch)
+    metrics.update(loss=loss, logits=logits, labels=batch['label'])
+
+def main():
+    rng = np.random.default_rng(RNG_SEED)
+
+    train_images, train_labels, test_images, test_labels = load_cifar10()
+
+    print(f"Train: {train_images.shape} {train_labels.shape}")
+    print(f"Test:  {test_images.shape} {test_labels.shape}")
+
+    model = Net(rngs=nnx.Rngs(RNG_SEED))
+    optimizer = nnx.Optimizer(
+            model,
+            optax.adamw(learning_rate=LEARNING_RATE),  # can swap to optax.sgd(LEARNING_RATE, momentum=0.9)
+            wrt=nnx.Param
+    )
+    metrics = nnx.MultiMetric(
+            accuracy=nnx.metrics.Accuracy(),
+            loss=nnx.metrics.Average('loss'),
+    )
+
+    metrics_history = {
+            'train_loss': [],
+            'train_accuracy': [],
+            'test_loss': [],
+            'test_accuracy': [],
+    }
+
+    for epoch in range(NUM_EPOCHS):
+        # Training
+        model.train()
+        metrics.reset()
+        for batch in batch_iterator(train_images, train_labels, BATCH_SIZE, rng, shuffle=True):
+            train_step(model, optimizer, metrics, batch)
+        train_vals = metrics.compute()
+
+        # Evaluation
+        if (epoch + 1) % EVAL_EVERY == 0:
+            model.eval()
+            metrics.reset()
+            for batch in batch_iterator(test_images, test_labels, BATCH_SIZE, rng, shuffle=False):
+                eval_step(model, metrics, batch)
+            test_vals = metrics.compute()
+
+            metrics_history['train_loss'].append(train_vals['loss'])
+            metrics_history['train_accuracy'].append(train_vals['accuracy'])
+            metrics_history['test_loss'].append(test_vals['loss'])
+            metrics_history['test_accuracy'].append(test_vals['accuracy'])
+
+            print(
+                    f"Epoch {epoch+1}/{NUM_EPOCHS} "
+                    f"train_loss={train_vals['loss']:.4f} train_acc={train_vals['accuracy']:.4f} "
+                    f"test_loss={test_vals['loss']:.4f} test_acc={test_vals['accuracy']:.4f}"
+            )
+
+    return metrics_history, model
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement Grad-CAM visualization to understand model's feature
activation and decision-making process. Add functionality to
generate heatmaps for input images before and after training,
highlighting important regions for classification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CNN model with built-in Grad-CAM support, providing activation maps alongside predictions.
  * Introduced an end-to-end training pipeline for CIFAR-10, including batching, metrics, and evaluation.
  * Added a visualization workflow to create and save Grad-CAM overlays on images, available before and after training.
  * Supports both single-image and batch processing for Grad-CAM.
  * Provided a simple entry point to run training and generate visualizations for one sample per class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->