### PR TITLE
chore(deps): Update Python version and lock file dependencies

### DIFF
--- a/RAG_translate/translate.ipynb
+++ b/RAG_translate/translate.ipynb
@@ -6,8 +6,8 @@
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2026-01-06T18:58:33.032587Z",
-     "start_time": "2026-01-06T18:58:33.016683Z"
+     "end_time": "2026-01-09T15:51:19.945430Z",
+     "start_time": "2026-01-09T15:51:19.912746Z"
     }
    },
    "source": [
@@ -18,13 +18,13 @@
     "import textgrad as tg"
    ],
    "outputs": [],
-   "execution_count": 4
+   "execution_count": 17
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T18:51:28.707074Z",
-     "start_time": "2026-01-06T18:51:28.685840Z"
+     "end_time": "2026-01-09T10:12:16.557376Z",
+     "start_time": "2026-01-09T10:12:16.536075Z"
     }
    },
    "cell_type": "code",
@@ -35,25 +35,13 @@
    ],
    "id": "7d4f16cde6077034",
    "outputs": [],
-   "execution_count": 2
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
-   "source": [
-    "from textgrad.engine_experimental.litellm import LiteLLMEngine\n",
-    "\n",
-    "LiteLLMEngine(\"groq/openai/gpt-oss-120b\" , cache=True).generate(content=\"hello, what's 3+4\" , system_prompt=\"you are an assistant\")"
-   ],
-   "id": "474a25c1a814f09c"
+   "execution_count": 3
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T19:50:05.105569Z",
-     "start_time": "2026-01-06T19:50:05.058532Z"
+     "end_time": "2026-01-09T10:12:16.583316Z",
+     "start_time": "2026-01-09T10:12:16.560037Z"
     }
    },
    "cell_type": "code",
@@ -62,37 +50,30 @@
     "from textgrad.engine.local_model_openai_api import ChatExternalClient\n",
     "\n",
     "# start a server with lm-studio and point it to the right address; here we use the default address.\n",
-    "client = OpenAI(base_url=\"https://api.groq.com/openai/v1\" , api_key=\"\")\n",
+    "client = OpenAI(base_url=\"http://localhost:11434/v1/\" , api_key=\"ollama\")\n",
     "\n",
-    "engine = ChatExternalClient(client=client , model_string='openai/gpt-oss-120b')"
+    "engine = ChatExternalClient(client=client , model_string='zongwei/gemma3-translator:1b')"
    ],
    "id": "8614f2f1e1548508",
    "outputs": [],
-   "execution_count": 18
+   "execution_count": 4
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T19:50:05.819148Z",
-     "start_time": "2026-01-06T19:50:05.805286Z"
+     "end_time": "2026-01-09T10:12:16.850430Z",
+     "start_time": "2026-01-09T10:12:16.834279Z"
     }
    },
    "cell_type": "code",
    "source": [
     "tg.set_backward_engine(engine , override=True)\n",
     "\n",
-    "initial_solution = \"\"\"To solve the equation 3x^2 - 7x + 2 = 0, we use the quadratic formula:\n",
-    "x = (-b ± √(b^2 - 4ac)) / 2a\n",
-    "a = 3, b = -7, c = 2\n",
-    "x = (7 ± √((-7)^2 + 4(3)(2))) / 6\n",
-    "x = (7 ± √73) / 6\n",
-    "The solutions are:\n",
-    "x1 = (7 + √73)\n",
-    "x2 = (7 - √73)\"\"\"\n",
+    "initial_solution = \"\"\"Hello, how are you?\"\"\"\n",
     "\n",
     "solution = tg.Variable(initial_solution ,\n",
     "                       requires_grad=True ,\n",
-    "                       role_description=\"solution to the math question\")\n",
+    "                       role_description=\"Translate this sentence to French\")\n",
     "\n",
     "loss_system_prompt = tg.Variable(\"\"\"You will evaluate a solution to a math question.\n",
     "Do not attempt to solve it yourself, do not give a solution, only identify errors. Be super concise.\"\"\" ,\n",
@@ -104,13 +85,13 @@
    ],
    "id": "71634f6273781ad8",
    "outputs": [],
-   "execution_count": 19
+   "execution_count": 5
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T19:50:08.317299Z",
-     "start_time": "2026-01-06T19:50:06.599586Z"
+     "end_time": "2026-01-09T10:12:20.411912Z",
+     "start_time": "2026-01-09T10:12:18.681290Z"
     }
    },
    "cell_type": "code",
@@ -124,35 +105,86 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "- The discriminant should be \\(b^{2}-4ac = (-7)^{2}-4\\cdot3\\cdot2 = 49-24 = 25\\), not \\(49+24 = 73\\).  \n",
-      "- The denominator \\(2a = 6\\) must be kept in the final expressions; the solutions are \\(\\displaystyle x=\\frac{7\\pm5}{6}\\), i.e. \\(x=2\\) and \\(x=\\frac13\\).  \n",
-      "- As written, the answers \\((7\\pm\\sqrt{73})\\) omit the division by 6 and use the wrong discriminant.\n"
+      "I'm doing well, thank you for asking!\n"
      ]
     }
    ],
-   "execution_count": 20
+   "execution_count": 6
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T19:06:02.059869Z",
-     "start_time": "2026-01-06T19:06:02.025817Z"
+     "end_time": "2026-01-09T10:13:10.960503Z",
+     "start_time": "2026-01-09T10:13:06.189897Z"
     }
    },
    "cell_type": "code",
    "source": [
-    "# print textgrad.engine info\n",
-    "print(tg.engine.info( ))"
+    "loss.backward( )\n",
+    "optimizer.step( )\n",
+    "print(solution.value)"
    ],
-   "id": "1f166a0897787e19",
+   "id": "1ca9a42676359b83",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Engine model: mlabonne/NeuralBeagle14-7B-GGUF\n",
-      "Engine instance: <textgrad.engine.local_model_openai_api.ChatExternalClient object at 0x110a423c0>\n"
+      "Bonjour, comment allez-vous?\n"
      ]
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T15:31:20.603781Z",
+     "start_time": "2026-01-09T15:31:12.872016Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "ds = load_dataset(\"aimped/medical-translation-test-set\")"
+   ],
+   "id": "c5d05022ebd784c1",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jonathansuru/PycharmProjects/OpenLabs/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "execution_count": 8
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T15:31:42.509880Z",
+     "start_time": "2026-01-09T15:31:42.473351Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "ds[ \"en_fr\" ]",
+   "id": "c70677657279f71",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dataset({\n",
+       "    features: ['source', 'target'],\n",
+       "    num_rows: 1049\n",
+       "})"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "execution_count": 10
@@ -160,79 +192,23 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-01-06T19:17:01.750208Z",
-     "start_time": "2026-01-06T19:17:01.739238Z"
+     "end_time": "2026-01-09T15:49:08.589388Z",
+     "start_time": "2026-01-09T15:49:08.556742Z"
     }
    },
    "cell_type": "code",
    "source": [
-    "import os\n",
-    "\n",
-    "# env variable\n",
-    "os.environ[ 'GROQ_API_KEY' ] = \"\""
+    "# split into train_set, val_set, test_set\n",
+    "train_size = int(0.8 * len(ds[ \"en_fr\" ]))\n",
+    "val_size = int(0.1 * len(ds[ \"en_fr\" ]))\n",
+    "test_size = len(ds[ \"en_fr\" ]) - train_size - val_size\n",
+    "train_set = ds[ \"en_fr\" ].select(range(0 , train_size))\n",
+    "val_set = ds[ \"en_fr\" ].select(range(train_size , train_size + val_size))\n",
+    "test_set = ds[ \"en_fr\" ].select(range(train_size + val_size , len(ds[ \"en_fr\" ])))"
    ],
-   "id": "6eb4c679c5fdbc27",
+   "id": "c9661a62a6c5626c",
    "outputs": [],
    "execution_count": 12
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-01-06T19:18:40.935576Z",
-     "start_time": "2026-01-06T19:18:40.318906Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "from litellm import completion\n",
-    "\n",
-    "response = completion(\n",
-    "        model=\"groq/openai/gpt-oss-120b\" ,\n",
-    "        messages=[\n",
-    "                { \"role\" : \"user\" , \"content\" : \"hello from litellm\" }\n",
-    "        ] ,\n",
-    ")\n",
-    "print(response)"
-   ],
-   "id": "9f86a316fbc8f6d9",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ModelResponse(id='chatcmpl-04017b6a-6a30-4d40-8141-8d3aa9151b44', created=1767727120, model='openai/gpt-oss-120b', object='chat.completion', system_fingerprint='fp_fe269835c7', choices=[Choices(finish_reason='stop', index=0, message=Message(content='Hello! 👋 How can I assist you today?', role='assistant', tool_calls=None, function_call=None, provider_specific_fields=None, reasoning='We need to respond. The user says \"hello from litellm\". Probably a greeting. Should respond friendly.'))], usage=Usage(completion_tokens=44, prompt_tokens=76, total_tokens=120, completion_tokens_details=CompletionTokensDetailsWrapper(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=24, rejected_prediction_tokens=None, text_tokens=None, image_tokens=None), prompt_tokens_details=None, queue_time=0.044147329, prompt_time=0.003207882, completion_time=0.092844607, total_time=0.096052489), usage_breakdown=None, x_groq={'id': 'req_01keabygb4f05bfcyf935qxqaf', 'seed': 565054761}, service_tier='auto')\n"
-     ]
-    }
-   ],
-   "execution_count": 15
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-01-06T19:20:41.075023Z",
-     "start_time": "2026-01-06T19:20:40.390273Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "from textgrad.engine_experimental.litellm import LiteLLMEngine\n",
-    "\n",
-    "LiteLLMEngine(\"groq/openai/gpt-oss-120b\" , cache=True).generate(content=\"hello, what's 3+4\" , system_prompt=\"you are an assistant\")"
-   ],
-   "id": "f5448c7d7d43d3b9",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Hello!\\u202fThe sum of\\u202f3\\u202fand\\u202f4\\u202fis\\u202f7.'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 17
   },
   {
    "metadata": {},
@@ -240,7 +216,684 @@
    "outputs": [],
    "execution_count": null,
    "source": "",
-   "id": "c5d05022ebd784c1"
+   "id": "8c9c57359e23a9c0"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T15:49:33.928753Z",
+     "start_time": "2026-01-09T15:49:33.866967Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "test_set[ \"source\" ]",
+   "id": "4f457d3c7a27253d",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Column(['A method as claimed in Claim 1, wherein the inhibitor added is selected from human α 1 -antitrypsin, human serum or plasma containing human α 1 -antitrypsin, animal serum or plasma containing a substance which can combine with free elastase in such a way that human α 1 -antitrypsin combines therewith to inhibit elastase activity, and a synthetic material containing a substance which can combine with free elastase in such a way that human α 1 -antitrypsin combines therewith to inhibit elastase activity.', 'This invention provides oligonucleotide agents that modulate an immune response by stimulating IFN production and methods of using such agents for therapeutic treatments of mammals.', 'Tel: +386 (0)1 580 00 10 Slovenská republika Eli Lilly Slovakia, s. r. o.', 'A nanoparticle according to claim 18, wherein the osteotropic gene or gene segment is selected from bone morphogenic proteins (BMP2 and 4 and others), transforming growth factor, such as TGF-β1-3, activin, phosphoproteins, osteonectin, osteopontin, bone sialoprotein, osteocalcin, vitamin-k dependent proteins, glycoproteins, and collagen (at least I and II).', 'Thus, our conclusion is that the agonist/antagonist balance would have a protective role of the joint stability; the occurrence of a muscle agonist / antagonist imbalance may be secondary to an anatomical lesion and mark the sign of its long and/or pejorative evolution', ...])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 14
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T16:22:33.773796Z",
+     "start_time": "2026-01-09T16:22:33.713108Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import textgrad as tg\n",
+    "\n",
+    "# 1. Set the TextGrad backend engine (for generating gradients)\n",
+    "# Ensure you have your API key set for OpenAI or your chosen provider\n",
+    "tg.set_backward_engine(engine , override=True)\n",
+    "\n",
+    "# 2. Define Variables\n",
+    "# Source Text (English)\n",
+    "source_text = \"The quick brown fox jumps over the lazy dog.\"\n",
+    "\n",
+    "# Initial Translation (French)\n",
+    "# Note: This translation is intentionally imperfect to demonstrate optimization.\n",
+    "# \"au-dessus le\" is a grammatical error; it should be \"au-dessus du\".\n",
+    "initial_translation = \"Le renard brun rapide saute par-dessus du chien paresseux.\"\n",
+    "\n",
+    "# Reference Translations (French)\n",
+    "# These are \"Gold Standard\" translations for comparison.\n",
+    "reference_translations = [\n",
+    "        \"Le vif renard brun saute par-dessus le chien paresseux.\"\n",
+    "]\n",
+    "\n",
+    "# Wrap text in TextGrad Variables\n",
+    "source = tg.Variable(source_text , requires_grad=False , role_description=\"source text in English\")\n",
+    "translation = tg.Variable(initial_translation , requires_grad=True , role_description=\"French translation to optimize\")\n",
+    "\n",
+    "# Wrap references in Variables so they can be passed around easily\n",
+    "ref_vars = [ tg.Variable(ref , requires_grad=False , role_description=\"reference French translation\") for ref in reference_translations ]\n",
+    "\n",
+    "\n",
+    "# 3. Define Custom BLEU Loss Function\n",
+    "def calculate_bleu_loss(prediction , ground_truth) :\n",
+    "    \"\"\"\n",
+    "    Calculates the BLEU score between the candidate translation (prediction)\n",
+    "    and reference translations (ground_truth).\n",
+    "    Returns a TextGrad Variable representing the negative BLEU score.\n",
+    "    \"\"\"\n",
+    "    # sacrebleu.corpus_bleu expects:\n",
+    "    # sys_stream: a list of hypothesis strings (candidate translations)\n",
+    "    # ref_streams: a list of lists of reference strings\n",
+    "\n",
+    "    # We pass a list of 1 string because we are processing one sentence at a time here\n",
+    "    hypothesis_list = [ prediction.value ]\n",
+    "\n",
+    "    # Extract the string values from the reference Variables\n",
+    "    # The inner list represents the multiple references for the single sentence\n",
+    "    references_list = [ [ ref.value for ref in ground_truth ] ]\n",
+    "\n",
+    "    # Calculate BLEU score\n",
+    "    # sacrebleu automatically handles French tokenization (lowercasing, splitting \"l'animal\", etc.)\n",
+    "    bleu = sacrebleu.corpus_bleu(hypothesis_list , references_list)\n",
+    "    bleu_score = bleu.score\n",
+    "\n",
+    "    # Return NEGATIVE BLEU score because TextGrad minimizes loss\n",
+    "    return tg.Variable(str(-bleu_score) , requires_grad=True , role_description=\"negative BLEU score\")\n",
+    "\n",
+    "\n",
+    "# 4. Define Optimizer\n",
+    "# We optimize the 'translation' variable\n",
+    "optimizer = tg.TGD(parameters=[ translation ])\n",
+    "\n",
+    "# 5. Optimization Loop\n",
+    "print(f\"Source: {source.value}\")\n",
+    "print(f\"Initial Translation: {translation.value}\\n\")\n",
+    "\n",
+    "for i in range(3) :\n",
+    "    # --- Step 1: Evaluate ---\n",
+    "    # Calculate loss using our custom function\n",
+    "    loss = calculate_bleu_loss(translation , ref_vars)\n",
+    "\n",
+    "    print(f\"--- Iteration {i + 1} ---\")\n",
+    "    # Print the actual BLEU score (negate the loss value to get it back to positive)\n",
+    "    print(f\"Current BLEU Score: {-float(loss.value):.2f}\")\n",
+    "\n",
+    "    # --- Step 2: Backward Pass ---\n",
+    "    # Generate textual gradients based on the loss\n",
+    "    loss.backward( )\n",
+    "\n",
+    "    # --- Step 3: Update ---\n",
+    "    # Update the translation variable based on the gradients\n",
+    "    optimizer.step( )\n",
+    "\n",
+    "    print(f\"Updated Translation: {translation.value}\\n\")\n",
+    "\n",
+    "print(\"Optimization Complete.\")"
+   ],
+   "id": "82afb8c3f4625d9f",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source: The quick brown fox jumps over the lazy dog.\n",
+      "Initial Translation: Le renard brun rapide saute par-dessus du chien paresseux.\n",
+      "\n",
+      "--- Iteration 1 ---\n",
+      "Current BLEU Score: 23.74\n",
+      "Updated Translation: Le renard brun rapide saute par-dessus du chien paresseux.\n",
+      "\n",
+      "--- Iteration 2 ---\n",
+      "Current BLEU Score: 23.74\n",
+      "Updated Translation: Le renard brun rapide saute par-dessus du chien paresseux.\n",
+      "\n",
+      "--- Iteration 3 ---\n",
+      "Current BLEU Score: 23.74\n",
+      "Updated Translation: Le renard brun rapide saute par-dessus du chien paresseux.\n",
+      "\n",
+      "Optimization Complete.\n"
+     ]
+    }
+   ],
+   "execution_count": 23
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:03:44.006738Z",
+     "start_time": "2026-01-09T17:03:43.962032Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def eval_sample(x , y , model) :\n",
+    "    \"\"\"\n",
+    "    This function allows us to evaluate if an answer to a question in the prompt is a good answer.\n",
+    "\n",
+    "    \"\"\"\n",
+    "    x = tg.Variable(x , requires_grad=False , role_description=\"query to the language model\")\n",
+    "\n",
+    "    references_list = [ y ]\n",
+    "    y = tg.Variable(y , requires_grad=False , role_description=\"correct answer for the query\")\n",
+    "    response = model(x)\n",
+    "\n",
+    "    hypothesis_list = [ response.value ]\n",
+    "    print(\"Hypothesis: \" , response)\n",
+    "    # Calculate BLEU score\n",
+    "    # sacrebleu automatically handles French tokenization (lowercasing, splitting \"l'animal\", etc.)\n",
+    "    bleu = sacrebleu.corpus_bleu(hypothesis_list , references_list)\n",
+    "    bleu_score = bleu.score\n",
+    "    return tg.Variable(str(-bleu_score) , requires_grad=True , role_description=\"negative BLEU score\")"
+   ],
+   "id": "f1127441d9e7f236",
+   "outputs": [],
+   "execution_count": 36
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:03:45.230707Z",
+     "start_time": "2026-01-09T17:03:45.116148Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# test on a sample from the test set\n",
+    "sample = test_set[ 0 ]\n",
+    "x = \"Translate this sentence to French: \" + sample[ \"source\" ]\n",
+    "y = sample[ \"target\" ]\n",
+    "\n",
+    "system_prompt = tg.Variable(\"Translate this sentence to French.\" ,\n",
+    "                            requires_grad=True ,\n",
+    "                            role_description=\"system prompt to the language model\")\n",
+    "model = tg.BlackboxLLM(engine , system_prompt)\n",
+    "eval_sample(x , y , model)"
+   ],
+   "id": "8084ed009d548523",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hypothesis:  Here’s a translation of the sentence into French, aiming for accuracy and a slightly formal tone suitable for a scientific document:\n",
+      "\n",
+      "“Un procédé comme décrit dans la revendication 1, dans lequel l'inhibiteur ajouté est sélectionné à partir d'alpha-1-antitrypsin humain, serum ou plasma contenant de l'alpha-1-antitrypsin humain, serum ou plasma contenant une substance qui combine avec l'elastase d'une manière telle que l'alpha-1-antitrypsin combine avec elle à inhiber l'activité de l'elastase, et un matériau synthétique contenant une substance qui combine avec l'elastase d'une manière telle que l'alpha-1-antitrypsin combine avec elle à inhiber l'activité de l'elastase.”\n",
+      "\n",
+      "Here's a breakdown of why I chose these words:\n",
+      "\n",
+      "*   **“Un procédé comme décrit dans la revendication 1”** - \"A method as described in Claim 1\" - This is a standard and accurate way to introduce the subject.\n",
+      "*   **“dans lequel”** - \"wherein\" -  A more formal way to introduce the concept.\n",
+      "*   **“l'inhibiteur ajouté est sélectionné à partir de”** - \"the inhibitor added is selected from\" - Clear and precise.\n",
+      "*   **“alpha-1-antitrypsin humain”** - \"human α 1 -antitrypsin\" -  Direct translation.\n",
+      "*   **“serum ou plasma contenant de l'alpha-1-antitrypsin humain”** - \"or plasma containing human α 1 -antitrypsin human\" -  A more precise and natural phrasing.\n",
+      "*   **“une substance qui combine avec l'elastase d'une manière telle que…”** - \"a substance which combines with elastase in such a way that...\" -  This is a standard way to express the combined action.\n",
+      "*   **“à inhiber l'activité de l'elastase”** - \"to inhibit elastase activity\" -  Direct and accurate.\n",
+      "\n",
+      "**Important Note:**  This translation is for a technical context.  If you need a translation for a general audience, you might need to simplify the language slightly.\n",
+      "\n",
+      "Do you have any specific context or area of focus for this translation?\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Variable(value=-0.0, role=negative BLEU score, grads=set())"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 37
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T16:57:17.860634Z",
+     "start_time": "2026-01-09T16:57:17.828493Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "sample",
+   "id": "3fe2286f345e446d",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'source': 'A method as claimed in Claim 1, wherein the inhibitor added is selected from human α 1 -antitrypsin, human serum or plasma containing human α 1 -antitrypsin, animal serum or plasma containing a substance which can combine with free elastase in such a way that human α 1 -antitrypsin combines therewith to inhibit elastase activity, and a synthetic material containing a substance which can combine with free elastase in such a way that human α 1 -antitrypsin combines therewith to inhibit elastase activity.',\n",
+       " 'target': \"Un procédé selon la Revendication 1, dans lequel l'inhibiteur ajouté est sélectionné parmi l'α 1 -antitrypsine, du sérum ou du plasma humain contenant de l'α 1 -antitrypsine humaine, du sérum ou du plasma animal contenant une substance qui peut se combiner à l'élastase libre de telle sorte que l'α 1 -antitrypsine humaine s'y combine pour inhiber l'activité de l'élastase, et une matière synthétique contenant une substance qui peut se combiner à l'élastase libre de telle sorte que l'α 1 -antitrypsine s'y combine pour inhiber l'activité de l'élastase.\"}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 26
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:08:00.097742Z",
+     "start_time": "2026-01-09T17:07:59.061214Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "\n",
+    "import dspy\n",
+    "\n",
+    "lm = dspy.LM(\"openai/zongwei/gemma3-translator:1b\" , api_key=\"ollama\" , api_base=\"http://localhost:11434/v1/\")\n",
+    "dspy.configure(lm=lm)"
+   ],
+   "id": "bb06ddb4f0264511",
+   "outputs": [],
+   "execution_count": 38
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:10:20.561814Z",
+     "start_time": "2026-01-09T17:10:18.484407Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "\n",
+    "rag = dspy.ChainOfThought(\"question -> response\")\n",
+    "\n",
+    "question = \"Translate this sentence to French: What's the name of the castle that David Gregory inherited?\"\n",
+    "rag(question=question)"
+   ],
+   "id": "a8fd8057c7330388",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(\n",
+       "    reasoning='The sentence is a straightforward question asking for the name of a castle. French doesn’t require a translation – it’s simply asking for the name.',\n",
+       "    response='Le nom du château que David Gregory a hérité ?'\n",
+       ")"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 43
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:21:54.412886Z",
+     "start_time": "2026-01-09T17:21:54.315473Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import dspy\n",
+    "import sacrebleu\n",
+    "\n",
+    "# 1. Configure DSPy with your LLM\n",
+    "# Make sure OPENAI_API_KEY is set in your environment variables\n",
+    "lm = dspy.LM(\"openai/zongwei/gemma3-translator:1b\" , api_key=\"ollama\" , api_base=\"http://localhost:11434/v1/\")\n",
+    "dspy.configure(lm=lm)\n",
+    "\n",
+    "\n",
+    "# 2. Define the Signature (Input/Output interface)\n",
+    "class FrenchTranslation(dspy.Signature) :\n",
+    "    \"\"\"Translate English sentences to French accurately and fluently.\"\"\"\n",
+    "    english_sentence = dspy.InputField(desc=\"The sentence in English to translate.\")\n",
+    "    french_translation = dspy.OutputField(desc=\"The translation in French.\")\n",
+    "\n",
+    "\n",
+    "# 3. Define the Metric (BLEU Score)\n",
+    "def bleu_metric(gold , pred , trace=None) :\n",
+    "    \"\"\"\n",
+    "    DSPy metric function.\n",
+    "    - gold: The example from the dataset containing the ground truth.\n",
+    "    - pred: The prediction object from the LLM containing the output.\n",
+    "    \"\"\"\n",
+    "    # Extract the hypothesis (prediction) and reference (gold)\n",
+    "    hypothesis = [ pred.french_translation ]\n",
+    "    references = [ [ gold.french_translation ] ]\n",
+    "\n",
+    "    # Calculate BLEU score using sacrebleu\n",
+    "    bleu = sacrebleu.corpus_bleu(hypothesis , references)\n",
+    "    return bleu.score\n",
+    "\n",
+    "\n",
+    "# 4. Prepare Data (Trainset)\n",
+    "# DSPy needs a small set of examples to \"bootstrap\" and optimize the prompt.\n",
+    "trainset = [\n",
+    "        dspy.Example(\n",
+    "                english_sentence=\"The quick brown fox jumps over the lazy dog.\" ,\n",
+    "                french_translation=\"Le vif renard brun saute par-dessus le chien paresseux.\"\n",
+    "        ).with_inputs(\"english_sentence\") ,\n",
+    "\n",
+    "        dspy.Example(\n",
+    "                english_sentence=\"Hello, how are you?\" ,\n",
+    "                french_translation=\"Bonjour, comment allez-vous ?\"\n",
+    "        ).with_inputs(\"english_sentence\") ,\n",
+    "\n",
+    "        dspy.Example(\n",
+    "                english_sentence=\"Machine learning is fascinating.\" ,\n",
+    "                french_translation=\"L'apprentissage automatique est fascinant.\"\n",
+    "        ).with_inputs(\"english_sentence\") ,\n",
+    "]\n",
+    "\n",
+    "# 5. Initialize the Student Program\n",
+    "# We start with a basic Predict module.\n",
+    "# DSPy will optimize this by filling in the \"few-shot\" examples in the prompt.\n",
+    "translator = dspy.Predict(FrenchTranslation)\n",
+    "\n",
+    "# 6. Configure the Teleprompter (Optimizer)\n",
+    "# BootstrapFewShot: Selects the best examples from the trainset to include in the prompt\n",
+    "# to maximize the defined metric (BLEU score).\n",
+    "teleprompter = dspy.BootstrapFewShot(\n",
+    "        metric=bleu_metric ,\n",
+    "        max_bootstrapped_demos=3 ,  # Number of examples to include in the final prompt\n",
+    "        max_labeled_demos=1  # Number of fixed examples to always include\n",
+    ")\n",
+    "\n",
+    "# 7. Compile (Optimize) the Program\n",
+    "print(\"Compiling/Optimizing the translator based on BLEU score...\")\n",
+    "optimized_translator = teleprompter.compile(student=translator , trainset=trainset)\n",
+    "\n",
+    "print(\"\\n--- Optimization Complete ---\")\n",
+    "\n",
+    "# 8. Test the Optimized Program\n",
+    "test_sentence = \"The cat is sleeping on the mat.\"\n",
+    "print(f\"\\nSource: {test_sentence}\")\n",
+    "\n",
+    "# Run the optimized program\n",
+    "result = optimized_translator(english_sentence=test_sentence)\n",
+    "\n",
+    "# Print the Result\n",
+    "print(f\"\\nTranslation: {result.french_translation}\")\n",
+    "\n",
+    "# --- Safe History Inspection (Debugging) ---\n",
+    "# We wrap this in a check to avoid the TypeError if history is None/empty\n",
+    "history = lm.inspect_history(n=1)\n",
+    "if history :\n",
+    "    print(\"\\n--- Last LLM Call (Prompt) ---\")\n",
+    "    # We limit the print length to keep it readable\n",
+    "    print(history[ -1 ][ 'messages' ][ 0 ][ 'content' ][ :500 ] + \"...\")\n",
+    "else :\n",
+    "    print(\"\\n[Note: LLM history tracking is empty or not available in this configuration]\")\n",
+    "\n",
+    "# Optional: Calculate BLEU for this specific test if you have a reference\n",
+    "reference = \"Le chat dort sur le tapis.\"\n",
+    "bleu_test = sacrebleu.corpus_bleu([ result.french_translation ] , [ [ reference ] ])\n",
+    "print(f\"\\nTest BLEU Score (vs reference): {bleu_test.score:.2f}\")"
+   ],
+   "id": "6603beab319d2cb3",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling/Optimizing the translator based on BLEU score...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 3/3 [00:00<00:00, 67.54it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapped 2 full traces after 2 examples for up to 1 rounds, amounting to 3 attempts.\n",
+      "\n",
+      "--- Optimization Complete ---\n",
+      "\n",
+      "Source: The cat is sleeping on the mat.\n",
+      "\n",
+      "Translation: Le chat dort sur le tapis.\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\u001B[34m[2026-01-09T18:21:54.387267]\u001B[0m\n",
+      "\n",
+      "\u001B[31mSystem message:\u001B[0m\n",
+      "\n",
+      "Your input fields are:\n",
+      "1. `english_sentence` (str): The sentence in English to translate.\n",
+      "Your output fields are:\n",
+      "1. `french_translation` (str): The translation in French.\n",
+      "All interactions will be structured in the following way, with the appropriate values filled in.\n",
+      "\n",
+      "[[ ## english_sentence ## ]]\n",
+      "{english_sentence}\n",
+      "\n",
+      "[[ ## french_translation ## ]]\n",
+      "{french_translation}\n",
+      "\n",
+      "[[ ## completed ## ]]\n",
+      "In adhering to this structure, your objective is: \n",
+      "        Translate English sentences to French accurately and fluently.\n",
+      "\n",
+      "\n",
+      "\u001B[31mUser message:\u001B[0m\n",
+      "\n",
+      "[[ ## english_sentence ## ]]\n",
+      "The quick brown fox jumps over the lazy dog.\n",
+      "\n",
+      "\n",
+      "\u001B[31mAssistant message:\u001B[0m\n",
+      "\n",
+      "[[ ## french_translation ## ]]\n",
+      "Le rapide renard brun saute par-dessus le chien paresseux.\n",
+      "\n",
+      "[[ ## completed ## ]]\n",
+      "\n",
+      "\n",
+      "\u001B[31mUser message:\u001B[0m\n",
+      "\n",
+      "[[ ## english_sentence ## ]]\n",
+      "Hello, how are you?\n",
+      "\n",
+      "\n",
+      "\u001B[31mAssistant message:\u001B[0m\n",
+      "\n",
+      "[[ ## french_translation ## ]]\n",
+      "Bonjour, comment allez-vous ?\n",
+      "\n",
+      "[[ ## completed ## ]]\n",
+      "\n",
+      "\n",
+      "\u001B[31mUser message:\u001B[0m\n",
+      "\n",
+      "[[ ## english_sentence ## ]]\n",
+      "The cat is sleeping on the mat.\n",
+      "\n",
+      "Respond with the corresponding output fields, starting with the field `[[ ## french_translation ## ]]`, and then ending with the marker for `[[ ## completed ## ]]`.\n",
+      "\n",
+      "\n",
+      "\u001B[31mResponse:\u001B[0m\n",
+      "\n",
+      "\u001B[32m[[ ## french_translation ## ]]\n",
+      "Le chat dort sur le tapis.\n",
+      "\n",
+      "[[ ## completed ## ]]\u001B[0m\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "[Note: LLM history tracking is empty or not available in this configuration]\n",
+      "\n",
+      "Test BLEU Score (vs reference): 100.00\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 46
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:27:34.220685Z",
+     "start_time": "2026-01-09T17:27:07.103642Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "qa = dspy.Predict('question: str -> response: str')\n",
+    "response = qa(question=\"what are high memory and low memory on linux?\")\n",
+    "\n",
+    "print(response.response)"
+   ],
+   "id": "64eaa6e18f8a4c78",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "High and low memory usage on Linux are complex and depend heavily on the specific workload and configuration. However, here’s a breakdown of general trends and factors:\n",
+      "\n",
+      "**High Memory Usage (Generally indicates potential for performance issues):**\n",
+      "\n",
+      "*   **Memory Leaks:** A common problem is memory leaks – where memory is allocated but never released.\n",
+      "*   **Large Applications/Processes:** Applications or processes that consume a lot of memory, especially during long-running tasks, can cause high memory usage.\n",
+      "*   **Memory-Intensive Tasks:** Tasks like video encoding, large database queries, or scientific simulations often have a significant memory footprint.\n",
+      "*   **Unoptimized Code:** Poorly written code can lead to excessive memory allocation.\n",
+      "*   **Insufficient RAM:** If the overall system has insufficient RAM to handle the load, higher memory usage becomes unavoidable.\n",
+      "*   **Data-Driven Systems:**  If a system relies heavily on reading data from disk (e.g., databases), memory pressure increases.\n",
+      "\n",
+      "**Low Memory Usage (Generally indicates system stability and responsiveness):**\n",
+      "\n",
+      "*   **Lightweight Applications:** Applications designed for minimal resource usage often consume less memory.\n",
+      "*   **Efficient Algorithms:** Using efficient algorithms and data structures can reduce memory consumption.\n",
+      "*   **Optimized Code:** Well-optimized code minimizes memory allocation.\n",
+      "*   **Memory Mapping:** Using memory mapping techniques can reduce the need to repeatedly allocate and deallocate memory.\n",
+      "*   **Caching:**  Caching frequently accessed data can significantly reduce memory usage by avoiding redundant computations.\n",
+      "*   **System Load:** A healthy system with minimal tasks often consumes less memory.\n",
+      "\n",
+      "**Factors Affecting Memory Usage:**\n",
+      "\n",
+      "*   **Number of Processes:** More running processes automatically consume more memory.\n",
+      "*   **File Handles:**  Opening and closing files creates file handles, which consume memory.\n",
+      "*   **Databases:** Database operations are a major memory consumer, especially when many queries are being performed.\n",
+      "*   **System Services:** Services like networking, printing, and system monitoring consume memory.\n",
+      "*   **User Profile:** The user’s desktop environment and applications also consume memory.\n",
+      "\n",
+      "**Tools for Monitoring:**\n",
+      "\n",
+      "*   **`top`:** Shows real-time process and memory usage.\n",
+      "*   **`htop`:** An enhanced version of `top` that provides more detailed information.\n",
+      "*   **`free`:** Displays available, used, and cached memory.\n",
+      "*   **`vmstat`:** Provides system-level statistics, including memory usage.\n",
+      "*   **`ps`:** Shows process information, including memory usage.\n",
+      "\n",
+      "**Linux Specific Considerations:**\n",
+      "\n",
+      "*   **Swap Space:**  The amount of swap space significantly impacts memory usage. More swap can delay usage of RAM,\n",
+      "*   **Kernel Memory Management:** Linux has sophisticated memory management, but it can still become a bottleneck if not configured properly.\n",
+      "*   **`VGTRAN`:** This is the mechanism Linux uses to manage memory between the kernel and the system, and it has a significant impact on overall memory usage.\n",
+      "\n",
+      "**It's important to note:**  Memory usage is often not a straightforward number. It’s often better to consider the *pattern* of usage – for example, spikes in memory usage might indicate a problem.\n",
+      "\n",
+      "In short, it’s a balance between using *less* memory and ensuring there’s enough available to handle all your workloads efficiently.\n"
+     ]
+    }
+   ],
+   "execution_count": 47
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-01-09T17:28:03.962849Z",
+     "start_time": "2026-01-09T17:28:03.895698Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "dspy.inspect_history(n=1)",
+   "id": "e735f3168b493bab",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\u001B[34m[2026-01-09T18:27:34.156401]\u001B[0m\n",
+      "\n",
+      "\u001B[31mSystem message:\u001B[0m\n",
+      "\n",
+      "Your input fields are:\n",
+      "1. `question` (str):\n",
+      "Your output fields are:\n",
+      "1. `response` (str):\n",
+      "All interactions will be structured in the following way, with the appropriate values filled in.\n",
+      "\n",
+      "Inputs will have the following structure:\n",
+      "\n",
+      "[[ ## question ## ]]\n",
+      "{question}\n",
+      "\n",
+      "Outputs will be a JSON object with the following fields.\n",
+      "\n",
+      "{\n",
+      "  \"response\": \"{response}\"\n",
+      "}\n",
+      "In adhering to this structure, your objective is: \n",
+      "        Given the fields `question`, produce the fields `response`.\n",
+      "\n",
+      "\n",
+      "\u001B[31mUser message:\u001B[0m\n",
+      "\n",
+      "[[ ## question ## ]]\n",
+      "what are high memory and low memory on linux?\n",
+      "\n",
+      "Respond with a JSON object in the following order of fields: `response`.\n",
+      "\n",
+      "\n",
+      "\u001B[31mResponse:\u001B[0m\n",
+      "\n",
+      "\u001B[32m{\n",
+      "  \"response\": \"High and low memory usage on Linux are complex and depend heavily on the specific workload and configuration. However, here’s a breakdown of general trends and factors:\\n\\n**High Memory Usage (Generally indicates potential for performance issues):**\\n\\n*   **Memory Leaks:** A common problem is memory leaks – where memory is allocated but never released.\\n*   **Large Applications/Processes:** Applications or processes that consume a lot of memory, especially during long-running tasks, can cause high memory usage.\\n*   **Memory-Intensive Tasks:** Tasks like video encoding, large database queries, or scientific simulations often have a significant memory footprint.\\n*   **Unoptimized Code:** Poorly written code can lead to excessive memory allocation.\\n*   **Insufficient RAM:** If the overall system has insufficient RAM to handle the load, higher memory usage becomes unavoidable.\\n*   **Data-Driven Systems:**  If a system relies heavily on reading data from disk (e.g., databases), memory pressure increases.\\n\\n**Low Memory Usage (Generally indicates system stability and responsiveness):**\\n\\n*   **Lightweight Applications:** Applications designed for minimal resource usage often consume less memory.\\n*   **Efficient Algorithms:** Using efficient algorithms and data structures can reduce memory consumption.\\n*   **Optimized Code:** Well-optimized code minimizes memory allocation.\\n*   **Memory Mapping:** Using memory mapping techniques can reduce the need to repeatedly allocate and deallocate memory.\\n*   **Caching:**  Caching frequently accessed data can significantly reduce memory usage by avoiding redundant computations.\\n*   **System Load:** A healthy system with minimal tasks often consumes less memory.\\n\\n**Factors Affecting Memory Usage:**\\n\\n*   **Number of Processes:** More running processes automatically consume more memory.\\n*   **File Handles:**  Opening and closing files creates file handles, which consume memory.\\n*   **Databases:** Database operations are a major memory consumer, especially when many queries are being performed.\\n*   **System Services:** Services like networking, printing, and system monitoring consume memory.\\n*   **User Profile:** The user’s desktop environment and applications also consume memory.\\n\\n**Tools for Monitoring:**\\n\\n*   **`top`:** Shows real-time process and memory usage.\\n*   **`htop`:** An enhanced version of `top` that provides more detailed information.\\n*   **`free`:** Displays available, used, and cached memory.\\n*   **`vmstat`:** Provides system-level statistics, including memory usage.\\n*   **`ps`:** Shows process information, including memory usage.\\n\\n**Linux Specific Considerations:**\\n\\n*   **Swap Space:**  The amount of swap space significantly impacts memory usage. More swap can delay usage of RAM,\\n*   **Kernel Memory Management:** Linux has sophisticated memory management, but it can still become a bottleneck if not configured properly.\\n*   **`VGTRAN`:** This is the mechanism Linux uses to manage memory between the kernel and the system, and it has a significant impact on overall memory usage.\\n\\n**It's important to note:**  Memory usage is often not a straightforward number. It’s often better to consider the *pattern* of usage – for example, spikes in memory usage might indicate a problem.\\n\\nIn short, it’s a balance between using *less* memory and ensuring there’s enough available to handle all your workloads efficiently.\"\n",
+      "\n",
+      "}\u001B[0m\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 48
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "88bf0518a6b7a1dd"
   }
  ],
  "metadata": {

--- a/RAG_translate/vector_db.py
+++ b/RAG_translate/vector_db.py
@@ -1,0 +1,62 @@
+import numpy as np
+import PIL as pil
+from sentence_transformers import SentenceTransformer
+from uform import Modality, get_model
+from usearch.index import Index
+
+processors, models = get_model("unum-cloud/uform3-image-text-english-small")
+
+
+# 1. Initialize the Embedding Model
+# This converts text to vectors (embeddings)
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+# 2. Your Original Data (The Text)
+documents = [
+    "USearch is a high-performance vector search engine.",
+    "Python is a popular programming language.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Vector databases are essential for AI applications.",
+]
+
+# 3. Create a Lookup Table (Map)
+# This is crucial! We map a unique ID (integer) to the text.
+# In a real app, this would likely be a Database ID (SQL/NoSQL).
+id_to_text = {i: text for i, text in enumerate(documents)}
+
+print(f"Lookup Table: {id_to_text}")
+# Output: {0: 'USearch is...', 1: 'Python is...', ...}
+
+
+# 4. Generate Embeddings
+vectors = model.encode(documents)
+
+# 5. Initialize and Populate USearch Index
+# We use the same keys (0, 1, 2, 3) as our lookup table
+index = Index(ndim=384, metric="cos", dtype="f16")
+keys = np.array(list(id_to_text.keys()))
+index.add(keys, vectors)
+
+
+# 6. Perform a Search
+query_text = "I need a fast search engine"
+query_vector = model.encode([query_text])[0]
+
+# Search for the top 2 most similar vectors
+matches = index.search(query_vector, 2)
+
+print(f"\n--- Search Results for: '{query_text}' ---")
+
+# 7. Retrieve the Original Text
+for match in matches:
+    # match.key is the ID we stored earlier
+    doc_id = match.key
+    distance = match.distance
+
+    # USE THE ID TO GET THE TEXT FROM OUR LOOKUP TABLE
+    original_text = id_to_text[doc_id]
+
+    print(f"ID: {doc_id}")
+    print(f"Text: {original_text}")
+    print(f"Distance: {distance:.4f}")
+    print("-" * 30)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,10 @@
 name = "openlabs"
 version = "0.1.0"
 description = "Add your description here"
-requires-python = ">=3.14"
+requires-python = ">=3.13"
 dependencies = [
+    "black>=25.12.0",
+    "ipykernel>=7.1.0",
     "ruff>=0.14.10",
     "ty>=0.0.9",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,20 +1,495 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = ">=3.13"
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "black"
+version = "25.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/07b458a3f1c525ac392b5edc6b191ff140b596f9d77092429417a54e249d/black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7", size = 659264, upload-time = "2025-12-08T01:40:52.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/52/c551e36bc95495d2aa1a37d50566267aa47608c81a53f91daa809e03293f/black-25.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a05ddeb656534c3e27a05a29196c962877c83fa5503db89e68857d1161ad08a5", size = 1923809, upload-time = "2025-12-08T01:46:55.126Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f7/aac9b014140ee56d247e707af8db0aae2e9efc28d4a8aba92d0abd7ae9d1/black-25.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9ec77439ef3e34896995503865a85732c94396edcc739f302c5673a2315e1e7f", size = 1742384, upload-time = "2025-12-08T01:49:37.022Z" },
+    { url = "https://files.pythonhosted.org/packages/74/98/38aaa018b2ab06a863974c12b14a6266badc192b20603a81b738c47e902e/black-25.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e509c858adf63aa61d908061b52e580c40eae0dfa72415fa47ac01b12e29baf", size = 1798761, upload-time = "2025-12-08T01:46:05.386Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3a/a8ac542125f61574a3f015b521ca83b47321ed19bb63fe6d7560f348bfe1/black-25.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:252678f07f5bac4ff0d0e9b261fbb029fa530cfa206d0a636a34ab445ef8ca9d", size = 1429180, upload-time = "2025-12-08T01:45:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2d/bdc466a3db9145e946762d52cd55b1385509d9f9004fec1c97bdc8debbfb/black-25.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bc5b1c09fe3c931ddd20ee548511c64ebf964ada7e6f0763d443947fd1c603ce", size = 1239350, upload-time = "2025-12-08T01:46:09.458Z" },
+    { url = "https://files.pythonhosted.org/packages/35/46/1d8f2542210c502e2ae1060b2e09e47af6a5e5963cb78e22ec1a11170b28/black-25.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a0953b134f9335c2434864a643c842c44fba562155c738a2a37a4d61f00cad5", size = 1917015, upload-time = "2025-12-08T01:53:27.987Z" },
+    { url = "https://files.pythonhosted.org/packages/41/37/68accadf977672beb8e2c64e080f568c74159c1aaa6414b4cd2aef2d7906/black-25.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2355bbb6c3b76062870942d8cc450d4f8ac71f9c93c40122762c8784df49543f", size = 1741830, upload-time = "2025-12-08T01:54:36.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/76/03608a9d8f0faad47a3af3a3c8c53af3367f6c0dd2d23a84710456c7ac56/black-25.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9678bd991cc793e81d19aeeae57966ee02909877cb65838ccffef24c3ebac08f", size = 1791450, upload-time = "2025-12-08T01:44:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
+    { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/75/9e12d4d42349b817cd545b89247696c67917aab907012ae5b64bbfea3199/debugpy-1.8.19.tar.gz", hash = "sha256:eea7e5987445ab0b5ed258093722d5ecb8bb72217c5c9b1e21f64efe23ddebdb", size = 1644590, upload-time = "2025-12-15T21:53:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/3d/388035a31a59c26f1ecc8d86af607d0c42e20ef80074147cd07b180c4349/debugpy-1.8.19-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:91e35db2672a0abaf325f4868fcac9c1674a0d9ad9bb8a8c849c03a5ebba3e6d", size = 2538859, upload-time = "2025-12-15T21:53:50.478Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/19/c93a0772d0962294f083dbdb113af1a7427bb632d36e5314297068f55db7/debugpy-1.8.19-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:85016a73ab84dea1c1f1dcd88ec692993bcbe4532d1b49ecb5f3c688ae50c606", size = 4292575, upload-time = "2025-12-15T21:53:51.821Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/56/09e48ab796b0a77e3d7dc250f95251832b8bf6838c9632f6100c98bdf426/debugpy-1.8.19-cp313-cp313-win32.whl", hash = "sha256:b605f17e89ba0ecee994391194285fada89cee111cfcd29d6f2ee11cbdc40976", size = 5286209, upload-time = "2025-12-15T21:53:53.602Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/4e/931480b9552c7d0feebe40c73725dd7703dcc578ba9efc14fe0e6d31cfd1/debugpy-1.8.19-cp313-cp313-win_amd64.whl", hash = "sha256:c30639998a9f9cd9699b4b621942c0179a6527f083c72351f95c6ab1728d5b73", size = 5328206, upload-time = "2025-12-15T21:53:55.433Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b9/cbec520c3a00508327476c7fce26fbafef98f412707e511eb9d19a2ef467/debugpy-1.8.19-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:1e8c4d1bd230067bf1bbcdbd6032e5a57068638eb28b9153d008ecde288152af", size = 2537372, upload-time = "2025-12-15T21:53:57.318Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5e/cf4e4dc712a141e10d58405c58c8268554aec3c35c09cdcda7535ff13f76/debugpy-1.8.19-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:d40c016c1f538dbf1762936e3aeb43a89b965069d9f60f9e39d35d9d25e6b809", size = 4268729, upload-time = "2025-12-15T21:53:58.712Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a3/c91a087ab21f1047db328c1d3eb5d1ff0e52de9e74f9f6f6fa14cdd93d58/debugpy-1.8.19-cp314-cp314-win32.whl", hash = "sha256:0601708223fe1cd0e27c6cce67a899d92c7d68e73690211e6788a4b0e1903f5b", size = 5286388, upload-time = "2025-12-15T21:54:00.687Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b8/bfdc30b6e94f1eff09f2dc9cc1f9cd1c6cde3d996bcbd36ce2d9a4956e99/debugpy-1.8.19-cp314-cp314-win_amd64.whl", hash = "sha256:8e19a725f5d486f20e53a1dde2ab8bb2c9607c40c00a42ab646def962b41125f", size = 5327741, upload-time = "2025-12-15T21:54:02.148Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3e/e27078370414ef35fafad2c06d182110073daaeb5d3bf734b0b1eeefe452/debugpy-1.8.19-py2.py3-none-any.whl", hash = "sha256:360ffd231a780abbc414ba0f005dad409e71c78637efe8f2bd75837132a41d38", size = 5292321, upload-time = "2025-12-15T21:54:16.024Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/a4/4948be6eb88628505b83a1f2f40d90254cab66abf2043b3c40fa07dfce0f/ipykernel-7.1.0.tar.gz", hash = "sha256:58a3fc88533d5930c3546dc7eac66c6d288acde4f801e2001e65edc5dc9cf0db", size = 174579, upload-time = "2025-10-27T09:46:39.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/17/20c2552266728ceba271967b87919664ecc0e33efca29c3efc6baf88c5f9/ipykernel-7.1.0-py3-none-any.whl", hash = "sha256:763b5ec6c5b7776f6a8d7ce09b267693b4e5ce75cb50ae696aaefb3c85e1ea4c", size = 117968, upload-time = "2025-10-27T09:46:37.805Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/dd/fb08d22ec0c27e73c8bc8f71810709870d51cadaf27b7ddd3f011236c100/ipython-9.9.0.tar.gz", hash = "sha256:48fbed1b2de5e2c7177eefa144aba7fcb82dac514f09b57e2ac9da34ddb54220", size = 4425043, upload-time = "2026-01-05T12:36:46.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/92/162cfaee4ccf370465c5af1ce36a9eacec1becb552f2033bb3584e6f640a/ipython-9.9.0-py3-none-any.whl", hash = "sha256:b457fe9165df2b84e8ec909a97abcf2ed88f565970efba16b1f7229c283d252b", size = 621431, upload-time = "2026-01-05T12:36:44.669Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/27/d10de45e8ad4ce872372c4a3a37b7b35b6b064f6f023a5c14ffcced4d59d/jupyter_client-8.7.0.tar.gz", hash = "sha256:3357212d9cbe01209e59190f67a3a7e1f387a4f4e88d1e0433ad84d7b262531d", size = 344691, upload-time = "2025-12-09T18:37:01.953Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f5/fddaec430367be9d62a7ed125530e133bfd4a1c0350fe221149ee0f2b526/jupyter_client-8.7.0-py3-none-any.whl", hash = "sha256:3671a94fd25e62f5f2f554f5e95389c2294d89822378a5f2dd24353e1494a9e0", size = 106215, upload-time = "2025-12-09T18:37:00.024Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
 
 [[package]]
 name = "openlabs"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "black" },
+    { name = "ipykernel" },
     { name = "ruff" },
     { name = "ty" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "black", specifier = ">=25.12.0" },
+    { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "ty", specifier = ">=0.0.9" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/2e/83722ece0f6ee24387d6cb830dd562ddbcd6ce0b9d76072c6849670c31b4/pathspec-1.0.1.tar.gz", hash = "sha256:e2769b508d0dd47b09af6ee2c75b2744a2cb1f474ae4b1494fd6a1b7a841613c", size = 129791, upload-time = "2026-01-06T13:02:55.15Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fe/2257c71721aeab6a6e8aa1f00d01f2a20f58547d249a6c8fef5791f559fc/pathspec-1.0.1-py3-none-any.whl", hash = "sha256:8870061f22c58e6d83463cfce9a7dd6eca0512c772c1001fb09ac64091816721", size = 54584, upload-time = "2026-01-06T13:02:53.601Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/cb/09e5184fb5fc0358d110fc3ca7f6b1d033800734d34cac10f4136cfac10e/psutil-7.2.1.tar.gz", hash = "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3", size = 490253, upload-time = "2025-12-29T08:26:00.169Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/8e/f0c242053a368c2aa89584ecd1b054a18683f13d6e5a318fc9ec36582c94/psutil-7.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d", size = 129624, upload-time = "2025-12-29T08:26:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/a58a4968f8990617decee234258a2b4fc7cd9e35668387646c1963e69f26/psutil-7.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49", size = 130132, upload-time = "2025-12-29T08:26:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6d/ed44901e830739af5f72a85fa7ec5ff1edea7f81bfbf4875e409007149bd/psutil-7.2.1-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc", size = 180612, upload-time = "2025-12-29T08:26:08.276Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/65/b628f8459bca4efbfae50d4bf3feaab803de9a160b9d5f3bd9295a33f0c2/psutil-7.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf", size = 183201, upload-time = "2025-12-29T08:26:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/23/851cadc9764edcc18f0effe7d0bf69f727d4cf2442deb4a9f78d4e4f30f2/psutil-7.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f", size = 139081, upload-time = "2025-12-29T08:26:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/59/82/d63e8494ec5758029f31c6cb06d7d161175d8281e91d011a4a441c8a43b5/psutil-7.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672", size = 134767, upload-time = "2025-12-29T08:26:14.528Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c2/5fb764bd61e40e1fe756a44bd4c21827228394c17414ade348e28f83cd79/psutil-7.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679", size = 129716, upload-time = "2025-12-29T08:26:16.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d2/935039c20e06f615d9ca6ca0ab756cf8408a19d298ffaa08666bc18dc805/psutil-7.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f", size = 130133, upload-time = "2025-12-29T08:26:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/19f1eb0e01d24c2b3eacbc2f78d3b5add8a89bf0bb69465bc8d563cc33de/psutil-7.2.1-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129", size = 181518, upload-time = "2025-12-29T08:26:20.241Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6d/7e18b1b4fa13ad370787626c95887b027656ad4829c156bb6569d02f3262/psutil-7.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a", size = 184348, upload-time = "2025-12-29T08:26:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/1672114392dd879586d60dd97896325df47d9a130ac7401318005aab28ec/psutil-7.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79", size = 140400, upload-time = "2025-12-29T08:26:23.993Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7b/d0e9d4513c46e46897b46bcfc410d51fc65735837ea57a25170f298326e6/psutil-7.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266", size = 135430, upload-time = "2025-12-29T08:26:25.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cf/5180eb8c8bdf6a503c6919f1da28328bd1e6b3b1b5b9d5b01ae64f019616/psutil-7.2.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42", size = 128137, upload-time = "2025-12-29T08:26:27.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1", size = 128947, upload-time = "2025-12-29T08:26:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8", size = 154694, upload-time = "2025-12-29T08:26:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6", size = 156136, upload-time = "2025-12-29T08:26:34.079Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ad/bbf6595a8134ee1e94a4487af3f132cef7fce43aef4a93b49912a48c3af7/psutil-7.2.1-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8", size = 148108, upload-time = "2025-12-29T08:26:36.225Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
 ]
 
 [[package]]
@@ -44,6 +519,57 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7e/f7b8d8c4453f305a51f80dbb49014257bb7d28ccb4bbb8dd328ea995ecad/tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843", size = 442163, upload-time = "2025-12-15T19:20:49.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/206f82d51e1bfa940ba366a8d2f83904b15942c45a78dd978b599870ab44/tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17", size = 445746, upload-time = "2025-12-15T19:20:51.491Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9d/1a3338e0bd30ada6ad4356c13a0a6c35fbc859063fa7eddb309183364ac1/tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335", size = 445083, upload-time = "2025-12-15T19:20:52.778Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f", size = 445315, upload-time = "2025-12-15T19:20:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/27/07/2273972f69ca63dbc139694a3fc4684edec3ea3f9efabf77ed32483b875c/tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84", size = 446003, upload-time = "2025-12-15T19:20:56.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/83/41c52e47502bf7260044413b6770d1a48dda2f0246f95ee1384a3cd9c44a/tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f", size = 445412, upload-time = "2025-12-15T19:20:57.398Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/bc96917f06cbee182d44735d4ecde9c432e25b84f4c2086143013e7b9e52/tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8", size = 445392, upload-time = "2025-12-15T19:20:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -66,4 +592,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9f/75951eb573b473d35dd9570546fc1319f7ca2d5b5c50a5825ba6ea6cb33a/ty-0.0.9-py3-none-win32.whl", hash = "sha256:1f20f67e373038ff20f36d5449e787c0430a072b92d5933c5b6e6fc79d3de4c8", size = 9176458, upload-time = "2026-01-05T12:24:32.559Z" },
     { url = "https://files.pythonhosted.org/packages/9b/80/b1cdf71ac874e72678161e25e2326a7d30bc3489cd3699561355a168e54f/ty-0.0.9-py3-none-win_amd64.whl", hash = "sha256:2c415f3bbb730f8de2e6e0b3c42eb3a91f1b5fbbcaaead2e113056c3b361c53c", size = 10040479, upload-time = "2026-01-05T12:24:42.697Z" },
     { url = "https://files.pythonhosted.org/packages/b5/8f/abc75c4bb774b12698629f02d0d12501b0a7dff9c31dc3bd6b6c6467e90a/ty-0.0.9-py3-none-win_arm64.whl", hash = "sha256:48e339d794542afeed710ea4f846ead865cc38cecc335a9c781804d02eaa2722", size = 9543127, upload-time = "2026-01-05T12:24:11.731Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]


### PR DESCRIPTION
Update Python version requirement from 3.14 to 3.13 and
add new dependencies to the lock file, including appnope,
asttokens, and black with their respective versions and
platform-specific wheel configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added translation optimization workflow with BLEU-based evaluation and feedback loop
  * Introduced vector database functionality for document similarity search and retrieval

* **Chores**
  * Lowered Python version requirement from 3.14 to 3.13
  * Added new dependencies: black and ipykernel

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->